### PR TITLE
Allow varied length hwaddr lists in ifconfig

### DIFF
--- a/lib/toolshed/net.ex
+++ b/lib/toolshed/net.ex
@@ -114,7 +114,10 @@ defmodule Toolshed.Net do
   defp print_if_info([]), do: :ok
 
   defp print_if_info([{:hwaddr, addr} | rest]) do
-    :io.format('    hwaddr ~2.16.0b:~2.16.0b:~2.16.0b:~2.16.0b:~2.16.0b:~2.16.0b~n', addr)
+    string_address = addr
+    |> Enum.map(&(:io_lib.format("~2.16.0b", [&1])))
+    |> Enum.join(":")
+    :io.format('    hwaddr ~s', string_address)
     print_if_info(rest)
   end
 

--- a/lib/toolshed/net.ex
+++ b/lib/toolshed/net.ex
@@ -117,7 +117,7 @@ defmodule Toolshed.Net do
     string_address = addr
     |> Enum.map(&(:io_lib.format("~2.16.0b", [&1])))
     |> Enum.join(":")
-    :io.format('    hwaddr ~s', string_address)
+    :io.format('    hwaddr ~s~n', [string_address])
     print_if_info(rest)
   end
 


### PR DESCRIPTION
Occasionally, my RPi0W will include a sit0 network interface when calling `:inet.getifaddrs()`. This will return a result that looks something like the below:
```
{:ok,
 [
    ...
   {'sit0',
    [flags: [], hwaddr: [0, 0, 0, 0]]},
   ...
 ]}
```

Because the `hwaddr` list only includes 4 values, the following exception is thrown when Toolshed tries to format the values:
```
** (ArgumentError) argument error
    (stdlib) :io.format(#PID<0.668.0>, '    hwaddr ~2.16.0b:~2.16.0b:~2.16.0b:~2.16.0b:~2.16.0b:~2.16.0b~n', [0, 0, 0, 0])
```

This change allows the `addr` list to be any length (although the most likely lengths are 4 or 6).

Open to any suggestions to make this better, since I am admittedly an elixir/nerves/networking n00b. 😺 