### PR TITLE
Add nerves_runtime as an optional dependency

### DIFF
--- a/lib/toolshed/nerves.ex
+++ b/lib/toolshed/nerves.ex
@@ -1,8 +1,4 @@
-# When https://github.com/elixir-lang/elixir/issues/8063 is available, change
-# this to `Mix.Project.config()[:target]`
-target = System.get_env("MIX_TARGET")
-
-if target != nil and target != "host" do
+if Code.ensure_loaded?(:nerves_runtime) do
   defmodule Toolshed.Nerves do
     @moduledoc """
     Helpers that are useful on Nerves devices
@@ -54,9 +50,5 @@ if target != nil and target != "host" do
         {output, _} -> {:error, output}
       end
     end
-  end
-else
-  defmodule Toolshed.Nerves do
-    # Empty if not running on Nerves
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,5 @@
 defmodule Toolshed.MixProject do
   use Mix.Project
-  @target Mix.Project.config()[:target]
 
   def project do
     [
@@ -23,18 +22,8 @@ defmodule Toolshed.MixProject do
   defp deps do
     [
       {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false},
-      {:dialyxir, "~> 1.0.0-rc.3", only: [:dev, :test], runtime: false}
-      | deps(@target)
-    ]
-  end
-
-  defp deps(host) when host == "host" or host == nil do
-    []
-  end
-
-  defp deps(_target) do
-    [
-      {:nerves_runtime, "~> 0.3"}
+      {:dialyxir, "~> 1.0.0-rc.3", only: [:dev, :test], runtime: false},
+      {:nerves_runtime, "~> 0.4", optional: true}
     ]
   end
 


### PR DESCRIPTION
This fixes compile time warnings 
```
==> toolshed
Compiling 7 files (.ex)
warning: function Nerves.Runtime.reboot/0 is undefined (module Nerves.Runtime is not available)
  lib/toolshed/nerves.ex:32
```

It also doest require toolshed to know about "MIX_TARGET".