### PR TITLE
Exclude Nerves.Runtime from xref

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,8 @@ defmodule Toolshed.MixProject do
       docs: [extras: ["README.md"]],
       description: description(),
       package: package(),
-      dialyzer: [plt_add_apps: [:iex]]
+      dialyzer: [plt_add_apps: [:iex]],
+      xref: [exclude: [Nerves.Runtime]]
     ]
   end
 
@@ -22,8 +23,7 @@ defmodule Toolshed.MixProject do
   defp deps do
     [
       {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false},
-      {:dialyxir, "~> 1.0.0-rc.3", only: [:dev, :test], runtime: false},
-      {:nerves_runtime, "~> 0.4", optional: true}
+      {:dialyxir, "~> 1.0.0-rc.3", only: [:dev, :test], runtime: false}
     ]
   end
 


### PR DESCRIPTION
This will prevent `toolshed` from building `nerves_runtime` and instead just exclude it from xref checks.