### PR TITLE
Add weather, qr_encode, and pastebin

### DIFF
--- a/lib/toolshed.ex
+++ b/lib/toolshed.ex
@@ -24,7 +24,9 @@ defmodule Toolshed do
     * `lsmod/0`        - print out what kernel modules have been loaded (Nerves-only)
     * `lsusb/0`        - print info on USB devices
     * `nslookup/1`     - query DNS to find an IP address
+    * `pastebin/1`     - post text to a pastebin server (requires networking)
     * `ping/2`         - ping a remote host (but use TCP instead of ICMP)
+    * `qr_encode/1`    - create a QR code (requires networking)
     * `reboot/0`       - reboots gracefully (Nerves-only)
     * `reboot!/0`      - reboots immediately  (Nerves-only)
     * `save_value/2`   - save a value to a file as Elixir terms (uses inspect)
@@ -34,6 +36,7 @@ defmodule Toolshed do
     * `tree/1`         - pretty print a directory tree
     * `uptime/0`       - print out the current Erlang VM uptime
     * `uname/0`        - print information about the running system (Nerves-only)
+    * `weather/0`      - get the local weather (requires networking)
 
   """
 
@@ -57,6 +60,7 @@ defmodule Toolshed do
       import Toolshed.Net
       import Toolshed.Misc
       import Toolshed.HW
+      import Toolshed.HTTP
 
       IO.puts([
         IO.ANSI.color(:rand.uniform(231) + 1),

--- a/lib/toolshed/http.ex
+++ b/lib/toolshed/http.ex
@@ -1,0 +1,84 @@
+defmodule Toolshed.HTTP do
+  @moduledoc """
+  Helpers that make HTTP requests
+  """
+
+  @doc """
+  Display the local weather
+
+  See http://wttr.in/:help for more information.
+  """
+  @spec weather() :: :"do not show this result in output"
+  def weather() do
+    # :inets isn't listed in the dependencies so that it can be optional.
+    _ = Application.ensure_all_started(:inets)
+
+    {:ok, {_status, _headers, body}} = :httpc.request('http://wttr.in/?An0')
+
+    body |> :binary.list_to_bin() |> IO.puts()
+    IEx.dont_display_result()
+  end
+
+  @doc """
+  Generate an ASCII art QR code
+
+  See https://github.com/chubin/qrenco.de for more information.
+  """
+  @spec qr_encode(String.t()) :: :"do not show this result in output"
+  def qr_encode(message) do
+    # :inets isn't listed in the dependencies so that it can be optional.
+    _ = Application.ensure_all_started(:inets)
+
+    encoded = message |> URI.encode() |> to_charlist()
+    form_data = [?x, ?= | encoded]
+
+    {:ok, {_status, _headers, body}} =
+      :httpc.request(
+        :post,
+        {'http://qrenco.de/', [{'User-Agent', 'curl'}], 'application/x-www-form-urlencoded',
+         form_data},
+        [],
+        []
+      )
+
+    body |> :binary.list_to_bin() |> IO.puts()
+    IEx.dont_display_result()
+  end
+
+  @doc """
+  Post text to a paste service
+
+  This is a convenient way of sharing text data with others. It currently
+  posts to "exbin.call-cc.be". Keep in mind that the text is posted in the
+  clear and the server may retain it indefinitely.
+
+  On success, this function returns a URL to the posted text.
+  """
+  @spec pastebin(String.t()) :: String.t() | {:error, term()}
+  def pastebin(contents) do
+    {:ok, socket} = :gen_tcp.connect('exbin.call-cc.be', 9999, [])
+    :ok = :gen_tcp.send(socket, contents)
+    :ok = :gen_tcp.shutdown(socket, :write)
+
+    case read_until_closed(socket) do
+      {:ok, result} ->
+        IO.iodata_to_binary(result) |> String.trim()
+
+      {:error, _message} = error ->
+        error
+    end
+  end
+
+  defp read_until_closed(socket, result \\ []) do
+    receive do
+      {:tcp, ^socket, bytes} ->
+        read_until_closed(socket, [result, bytes])
+
+      {:tcp_closed, ^socket} ->
+        {:ok, result}
+    after
+      1000 ->
+        {:error, :timeout}
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,7 @@ defmodule Toolshed.MixProject do
       docs: [extras: ["README.md"], main: "readme"],
       description: description(),
       package: package(),
-      dialyzer: [plt_add_apps: [:iex, :nerves_runtime]]
+      dialyzer: [plt_add_apps: [:iex, :nerves_runtime, :inets]]
     ]
   end
 


### PR DESCRIPTION
These utilities all require an Internet connection to work. `weather` is
convenient for seeing where a Nerves device is (via GeoIP) and what the
weather is there. `qr_encode` is useful for copying chunks of data like
serial numbers to your phone, and `pastebin` is useful for sharing logs
and other text.