### PR TITLE
Add multicast_addresses/0

### DIFF
--- a/lib/toolshed.ex
+++ b/lib/toolshed.ex
@@ -24,6 +24,7 @@ defmodule Toolshed do
     * `lsof/0`         - print out open file handles by OS process
     * `lsmod/0`        - print out what kernel modules have been loaded (Nerves-only)
     * `lsusb/0`        - print info on USB devices
+    * `multicast_addresses/0 - print out all multicast addresses
     * `nslookup/1`     - query DNS to find an IP address
     * `pastebin/1`     - post text to a pastebin server (requires networking)
     * `ping/2`         - ping a remote host (but use TCP instead of ICMP)
@@ -62,6 +63,7 @@ defmodule Toolshed do
       import Toolshed.Misc
       import Toolshed.HW
       import Toolshed.HTTP
+      import Toolshed.Multicast
 
       # If module docs have been stripped, then don't tell the user that they can
       # see them.

--- a/lib/toolshed/multicast.ex
+++ b/lib/toolshed/multicast.ex
@@ -1,0 +1,160 @@
+defmodule Toolshed.Multicast do
+  @moduledoc """
+  Multicast utilities
+  """
+
+  @doc """
+  List all active multicast addresses
+
+  This lists out multicast addresses by network interface
+  similar to `ip maddr show`. It currently only works on
+  Linux.
+  """
+  @spec multicast_addresses() :: :ok
+  def multicast_addresses() do
+    dev_mcast = read_or_empty("/proc/net/dev_mcast")
+    igmp = read_or_empty("/proc/net/igmp")
+    igmp6 = read_or_empty("/proc/net/igmp6")
+
+    process_proc(dev_mcast, igmp, igmp6)
+    |> IO.puts()
+  end
+
+  defp read_or_empty(path) do
+    case File.read(path) do
+      {:ok, contents} -> contents
+      _other -> ""
+    end
+  end
+
+  @doc """
+  Helper for processing the multicast subscription information files
+  """
+  @spec process_proc(String.t(), String.t(), String.t()) :: String.t()
+  def process_proc(dev_mcast, igmp, igmp6) do
+    all =
+      process_link(dev_mcast) ++
+        process_igmp(igmp) ++
+        process_igmp6(igmp6)
+
+    if_map =
+      Enum.group_by(all, fn {_type, index, ifname, _address} -> {index, ifname} end, fn {type,
+                                                                                         _index,
+                                                                                         _ifname,
+                                                                                         address} ->
+        {type, address}
+      end)
+
+    if_keys = Map.keys(if_map) |> Enum.sort()
+
+    Enum.map(if_keys, fn if_key -> format(if_key, if_map[if_key]) end)
+    |> IO.iodata_to_binary()
+  end
+
+  defp format({index, ifname}, addresses) do
+    header = "#{index}: #{ifname}\n"
+    lines = Enum.map(addresses, fn {type, address} -> "   #{type} #{address}\n" end)
+    [header, lines]
+  end
+
+  defp process_link(dev_mcast) do
+    dev_mcast
+    |> String.split("\n")
+    |> Enum.map(&process_one_link/1)
+    |> Enum.filter(fn x -> x end)
+  end
+
+  defp process_one_link(line) do
+    case String.split(line, " ", trim: true) do
+      [index, ifname, _users, _ignore, mac_address] ->
+        {:link, String.to_integer(index), ifname, to_pretty_mac(mac_address)}
+
+      _ ->
+        nil
+    end
+  end
+
+  defp to_pretty_mac(<<a::2-bytes, b::2-bytes, c::2-bytes, d::2-bytes, e::2-bytes, f::2-bytes>>) do
+    <<a::binary, ?:, b::binary, ?:, c::binary, ?:, d::binary, ?:, e::binary, ?:, f::binary>>
+  end
+
+  defp process_igmp(igmp) do
+    all_lines = String.split(igmp, "\n")
+
+    # Skip the header
+    lines = tl(all_lines)
+
+    parse_igmp_lines(0, :unknown, lines, [])
+  end
+
+  defp parse_igmp_lines(_index, _ifname, [], result), do: result
+
+  defp parse_igmp_lines(index, ifname, [<<lead_char, info::binary>> | rest], result)
+       when lead_char in [?\s, ?\t] do
+    case String.split(info, [" ", "\t"], trim: true) do
+      [address | _rest] ->
+        record = {:inet, index, ifname, to_pretty_ipv4(address)}
+        parse_igmp_lines(index, ifname, rest, [record | result])
+
+      other ->
+        IO.inspect(other)
+        parse_igmp_lines(index, ifname, rest, result)
+    end
+  end
+
+  defp parse_igmp_lines(index, ifname, [if_line | rest], result) do
+    case String.split(if_line, [" ", "\t"], trim: true) do
+      [new_index, new_ifname | _rest] ->
+        parse_igmp_lines(String.to_integer(new_index), new_ifname, rest, result)
+
+      _ ->
+        parse_igmp_lines(index, ifname, rest, result)
+    end
+  end
+
+  defp process_igmp6(igmp6) do
+    igmp6
+    |> String.split("\n")
+    |> Enum.map(&process_one_igmp6/1)
+    |> Enum.filter(fn x -> x end)
+  end
+
+  defp process_one_igmp6(line) do
+    case String.split(line, " ", trim: true) do
+      [index, ifname, address, _users, _offset, _ignore] ->
+        {:inet6, String.to_integer(index), ifname, to_pretty_ipv6(address)}
+
+      _ ->
+        nil
+    end
+  end
+
+  defp to_pretty_ipv4(<<a::2-bytes, b::2-bytes, c::2-bytes, d::2-bytes>>) do
+    {
+      String.to_integer(d, 16),
+      String.to_integer(c, 16),
+      String.to_integer(b, 16),
+      String.to_integer(a, 16)
+    }
+    |> :inet.ntoa()
+    |> to_string()
+  end
+
+  defp to_pretty_ipv6(
+         <<a::4-bytes, b::4-bytes, c::4-bytes, d::4-bytes, e::4-bytes, f::4-bytes, g::4-bytes,
+           h::4-bytes>>
+       ) do
+    {
+      String.to_integer(a, 16),
+      String.to_integer(b, 16),
+      String.to_integer(c, 16),
+      String.to_integer(d, 16),
+      String.to_integer(e, 16),
+      String.to_integer(f, 16),
+      String.to_integer(g, 16),
+      String.to_integer(h, 16)
+    }
+    |> :inet.ntoa()
+    |> to_string()
+  end
+end

--- a/test/multicast_test.exs
+++ b/test/multicast_test.exs
@@ -1,0 +1,46 @@
+defmodule MulticastTest do
+  use ExUnit.Case
+
+  test "parses proc files" do
+    # This formatting changes tabs and spaces. Linux does use tabs when
+    # formatting the igmp table.
+    dev_mcast = """
+    2    eth0            1     0     333300000001
+    2    eth0            1     0     01005e000001
+    2    eth0            1     0     3333ff6fb53c
+    """
+
+    igmp = """
+    Idx	Device    : Count Querier	Group    Users Timer	Reporter
+    1	lo        :     1      V3
+            010000E0     1 0:00000000		0
+    2	eth0      :     1      V3
+            010000E0     1 0:00000000		0
+    """
+
+    igmp6 = """
+    1    lo              ff020000000000000000000000000001     1 0000000C 0
+    1    lo              ff010000000000000000000000000001     1 00000008 0
+    2    eth0            ff0200000000000000000001ff6fb53c     1 00000004 0
+    2    eth0            ff020000000000000000000000000001     1 0000000C 0
+    2    eth0            ff010000000000000000000000000001     1 00000008 0
+    """
+
+    result = """
+    1: lo
+       inet 224.0.0.1
+       inet6 ff02::1
+       inet6 ff01::1
+    2: eth0
+       link 33:33:00:00:00:01
+       link 01:00:5e:00:00:01
+       link 33:33:ff:6f:b5:3c
+       inet 224.0.0.1
+       inet6 ff02::1:ff6f:b53c
+       inet6 ff02::1
+       inet6 ff01::1
+    """
+
+    assert Toolshed.Multicast.process_proc(dev_mcast, igmp, igmp6) == result
+  end
+end


### PR DESCRIPTION
This utility is useful to debugging multicast issues where you want to
see what multicast addresses have active subscriptions. This is all from
the Linux kernel's point of view.