### PR TITLE
Ignore wildcards from user on path completion

### DIFF
--- a/lib/toolshed/autocomplete.ex
+++ b/lib/toolshed/autocomplete.ex
@@ -90,13 +90,22 @@ defmodule Toolshed.Autocomplete do
     Path.wildcard(fragment <> "*", match_dot: true)
   end
 
+  defp safe_fragment?(fragment) do
+    # Protect against wildcard characters in the strings passed to Path.wildcard/2
+    not String.contains?(fragment, ["*", "?", "[", "]", "{", "}"])
+  end
+
   # Returns possible paths as [{path, dir?}]
   @doc false
   @spec find_possible_paths(String.t()) :: [{Path.t(), boolean}]
   def find_possible_paths(path_fragment) do
-    path_fragment
-    |> ls_prefix()
-    |> Enum.map(fn path -> {path, File.dir?(path)} end)
+    if safe_fragment?(path_fragment) do
+      path_fragment
+      |> ls_prefix()
+      |> Enum.map(fn path -> {path, File.dir?(path)} end)
+    else
+      []
+    end
   end
 
   # Look through a list of possible paths for the specified

--- a/test/toolshed/autocomplete_test.exs
+++ b/test/toolshed/autocomplete_test.exs
@@ -67,6 +67,16 @@ defmodule Toolshed.AutocompleteTest do
       assert {"lib", true} in Autocomplete.find_possible_paths("lib")
       assert {"lib/toolshed", true} in Autocomplete.find_possible_paths("lib/")
     end
+
+    test "ignores strings with wildcard chars" do
+      # Path.wildcard/2 is used in the implementation and we don't
+      # want to trigger full subdirectory traversals on path completion.
+      assert [] == Autocomplete.find_possible_paths("*")
+      assert [] == Autocomplete.find_possible_paths("/etc/*")
+      assert [] == Autocomplete.find_possible_paths("?i")
+      assert [] == Autocomplete.find_possible_paths("l[a-z]b")
+      assert [] == Autocomplete.find_possible_paths("{lib,test}")
+    end
   end
 
   describe "expand_path/2" do


### PR DESCRIPTION
If you typed `/*<tab>`, `Path.wildcard/2` was being called with `"/**"`
which would traverse the whole file system. This commit stops this and
other ways to mess up `Path.wildcard/2` via tab completion.