### PR TITLE
Add httpget/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* New features
+  * Add `httpget` command for performing HTTP GET requests and printing
+    the response to stdout or saving it to the filesystem.
+
 ## v0.2.17
 
 * Bug fixes

--- a/lib/toolshed.ex
+++ b/lib/toolshed.ex
@@ -18,6 +18,7 @@ defmodule Toolshed do
     * `fw_validate/0`  - marks the current image as valid (check Nerves system if supported)
     * `grep/2`         - print out lines that match a regular expression
     * `hex/1`          - print a number as hex
+    * `httpget/2`      - print or download the results of a HTTP GET request
     * `hostname/0`     - print our hostname
     * `ifconfig/0`     - print info on network interfaces
     * `load_term!/2`   - load a term that was saved by `save_term/2`

--- a/lib/toolshed/http.ex
+++ b/lib/toolshed/http.ex
@@ -67,6 +67,92 @@ defmodule Toolshed.HTTP do
     end
   end
 
+  @doc """
+  Perform a HTTP GET request for the specified URL
+
+  By default, the results are printed or you can optionally choose to download
+  it to a specific locatiion on the file system.
+
+  Options:
+
+  * `:dest` - Location to write the response to. Defaults to printing to the terminal.
+  * `:verbose` - Display request and response headers. Disabled by default.
+  """
+  def httpget(url, options \\ []) do
+    check_inets()
+
+    url = url_defaults(url)
+    dest = Keyword.get(options, :dest, nil)
+    verbose = Keyword.get(options, :verbose, false)
+
+    stream =
+      if dest != nil do
+        to_charlist(dest)
+      else
+        :self
+      end
+
+    request_headers = [{'User-Agent', 'curl'}]
+
+    if verbose do
+      display_headers(request_headers, ">")
+    end
+
+    Task.async(fn ->
+      {:ok, _ref} =
+        :httpc.request(
+          :get,
+          {to_charlist(url), request_headers},
+          [],
+          sync: false,
+          stream: stream
+        )
+
+      handle_stream(verbose)
+    end)
+    |> Task.await()
+
+    IEx.dont_display_result()
+  end
+
+  defp url_defaults(url) do
+    case URI.parse(url) do
+      %URI{scheme: nil} -> "http://#{url}"
+      _ -> url
+    end
+  end
+
+  defp display_headers(headers, prefix) do
+    Enum.each(headers, fn {k, v} ->
+      IO.puts(:stderr, "#{prefix} #{k}: #{v}")
+    end)
+  end
+
+  defp handle_stream(verbose) do
+    receive do
+      {:http, {_ref, :stream_start, headers}} ->
+        if verbose do
+          display_headers(headers, "<")
+        end
+
+        handle_stream(verbose)
+
+      {:http, {_ref, :stream, body}} ->
+        IO.write(body)
+        handle_stream(verbose)
+
+      {:http, {_ref, :stream_end, _headers}} ->
+        IO.puts("")
+        nil
+
+      {:http, {_ref, :saved_to_file}} ->
+        nil
+
+      other ->
+        IO.puts("other message: #{inspect(other)}")
+    end
+  end
+
   defp read_until_closed(socket, result \\ []) do
     receive do
       {:tcp, ^socket, bytes} ->

--- a/lib/toolshed/http.ex
+++ b/lib/toolshed/http.ex
@@ -71,11 +71,11 @@ defmodule Toolshed.HTTP do
   Perform a HTTP GET request for the specified URL
 
   By default, the results are printed or you can optionally choose to download
-  it to a specific locatiion on the file system.
+  it to a specific location on the file system.
 
   Options:
 
-  * `:dest` - Location to write the response to. Defaults to printing to the terminal.
+  * `:dest` - File path to write the response to. Defaults to printing to the terminal.
   * `:verbose` - Display request and response headers. Disabled by default.
   """
   def httpget(url, options \\ []) do


### PR DESCRIPTION
This utility covers a subset of curl like commands.
It performs an HTTP GET request on a specified URL and can print
or save the response to a local path.
It can display headers with a verbose switch.
It will auto add http:// if this is left off the URL.

Closes #50 